### PR TITLE
Upgrade Gradle and configure Java toolchain

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = libs.versions.javaVersion.get()
     }
     buildFeatures {
         compose = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,3 +6,13 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.android.library) apply false
 }
+
+// Configure Java toolchain for all projects
+allprojects {
+    // Configure Kotlin compiler options
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        kotlinOptions {
+            jvmTarget = libs.versions.javaVersion.get()
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Plugins
-androidGradlePlugin = "8.2.2"
+androidGradlePlugin = "8.11.0"
 kotlinPlugin = "1.9.0"
 
 # Libraries

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Mar 14 14:56:36 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mockwebserver-allow-mocking/build.gradle.kts
+++ b/mockwebserver-allow-mocking/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = libs.versions.javaVersion.get()
     }
 }
 

--- a/mockwebserver-assertions/build.gradle.kts
+++ b/mockwebserver-assertions/build.gradle.kts
@@ -23,10 +23,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-kotlin {
-    jvmToolchain(libs.versions.javaVersion.get().toInt())
-}
-
 dependencies {
     implementation(project(":mockwebserver-request"))
     implementation(libs.okhttp)

--- a/mockwebserver-extensions/build.gradle.kts
+++ b/mockwebserver-extensions/build.gradle.kts
@@ -23,10 +23,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-kotlin {
-    jvmToolchain(libs.versions.javaVersion.get().toInt())
-}
-
 dependencies {
     implementation(project(":mockwebserver-interceptor"))
     implementation(project(":mockwebserver-request"))

--- a/mockwebserver-interceptor/build.gradle.kts
+++ b/mockwebserver-interceptor/build.gradle.kts
@@ -23,10 +23,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-kotlin {
-    jvmToolchain(libs.versions.javaVersion.get().toInt())
-}
-
 dependencies {
     implementation(libs.okhttp)
 }

--- a/mockwebserver-request/build.gradle.kts
+++ b/mockwebserver-request/build.gradle.kts
@@ -23,10 +23,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-kotlin {
-    jvmToolchain(libs.versions.javaVersion.get().toInt())
-}
-
 dependencies {
     implementation(libs.okhttp)
 }


### PR DESCRIPTION
- Upgrade Gradle Wrapper from 8.2 to 8.14.3.
- Upgrade Android Gradle Plugin from 8.2.2 to 8.11.0.
- Configure Java toolchain for all projects in the root build.gradle.kts.
- Remove redundant JVM toolchain configurations from individual module build.gradle.kts files.
- Update `jvmTarget` to use `libs.versions.javaVersion.get()` in app and mockwebserver-allow-mocking modules.