### PR TITLE
Add Android tests to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,11 @@ jobs:
 
     - name: Build with Gradle
       run: ./gradlew build check
+
+    - name: Run Android Tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 29
+        arch: x86_64
+        profile: pixel
+        script: ./gradlew app:connectedCheck


### PR DESCRIPTION
This commit adds a step to the GitHub Actions workflow to run Android instrumented tests on an emulator.