### PR TITLE
 Enable Dependabot for Gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Enable version updates for Gradle
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "gradle"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
This PR introduces Dependabot configuration to automatically manage dependencies for Gradle and GitHub Actions.


## Key changes:
   - Added .github/dependabot.yml to configure weekly checks for updates.
   - Enabled version updates for the gradle and github-actions package ecosystems.
   - Set a limit of 5 open pull requests for each ecosystem.
   - Added labels for easier identification of Dependabot PRs.