### PR TITLE
Improve publishing and version management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build check
 
+    - name: Verify publishing works
+      run: ./gradlew publishToMavenLocal
+
     - name: Enable KVM for faster android tests
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ repositories {
 Add the dependency:
 ```kotlin
 dependencies {
-    androidTestImplementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-extensions:0.3.0'
-    androidTestImplementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-request:0.3.0'
-    implementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-interceptor:0.3.0'
+    androidTestImplementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-extensions:<version>'
+    androidTestImplementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-request:<version>'
+    implementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-interceptor:<version>'
 }
 ```
 
@@ -44,7 +44,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    debugImplementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-allow-mocking:0.3.0'
+    debugImplementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-allow-mocking:<version>'
 }
 ```
 
@@ -73,9 +73,11 @@ val retrofit = Retrofit.Builder()
 
 ```kotlin
 dependencies {
-    androidTestImplementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-assertions:0.3.0'
+    androidTestImplementation 'com.github.appunite.MockWebServer-Extensions:mockwebserver-assertions:<version>'
 }
 ```
+
+You can find specific versions on the [GitHub releases page](https://github.com/appunite/MockWebServer-Extensions/releases).
 
 
 You can check full example in the [app module](https://github.com/appunite/MockWebServer/tree/main/app/src).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,4 +15,14 @@ allprojects {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.javaVersion.get()))
         }
     }
+
+    plugins.withId("maven-publish") {
+        configure<PublishingExtension> {
+            // Set version for all publications
+            publications.withType<MavenPublication> {
+                groupId = "com.github.appunite.MockWebServer-Extensions"
+                version = System.getenv("version").orEmpty().ifEmpty { "0.0.1-SNAPSHOT" }
+            }
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,9 +16,6 @@ ktor = "3.2.1"
 kotlinxSerialization = "1.5.1"
 mockk = "1.13.5"
 
-# Project
-projectVersion = "0.3.0"
-
 # SDK
 compileSdk = "34"
 minSdk = "23"

--- a/mockwebserver-allow-mocking/build.gradle.kts
+++ b/mockwebserver-allow-mocking/build.gradle.kts
@@ -29,9 +29,7 @@ android {
 publishing {
     publications {
         create<MavenPublication>("release") {
-            groupId = "com.github.appunite.MockWebServer-Extensions"
             artifactId = "mockwebserver-allow-mocking"
-            version = libs.versions.projectVersion.get()
 
             afterEvaluate {
                 from(components["release"])

--- a/mockwebserver-assertions/build.gradle.kts
+++ b/mockwebserver-assertions/build.gradle.kts
@@ -7,9 +7,7 @@ plugins {
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            groupId = "com.github.appunite.MockWebServer-Extensions"
             artifactId = "mockwebserver-assertions"
-            version = libs.versions.projectVersion.get()
 
             afterEvaluate {
                 from(components["java"])

--- a/mockwebserver-extensions/build.gradle.kts
+++ b/mockwebserver-extensions/build.gradle.kts
@@ -7,9 +7,7 @@ plugins {
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            groupId = "com.github.appunite.MockWebServer-Extensions"
             artifactId = "mockwebserver-extensions"
-            version = libs.versions.projectVersion.get()
 
             afterEvaluate {
                 from(components["java"])

--- a/mockwebserver-interceptor/build.gradle.kts
+++ b/mockwebserver-interceptor/build.gradle.kts
@@ -7,9 +7,7 @@ plugins {
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            groupId = "com.github.appunite.MockWebServer-Extensions"
             artifactId = "mockwebserver-interceptor"
-            version = libs.versions.projectVersion.get()
 
             afterEvaluate {
                 from(components["java"])

--- a/mockwebserver-request/build.gradle.kts
+++ b/mockwebserver-request/build.gradle.kts
@@ -7,9 +7,7 @@ plugins {
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            groupId = "com.github.appunite.MockWebServer-Extensions"
             artifactId = "mockwebserver-request"
-            version = libs.versions.projectVersion.get()
 
             afterEvaluate {
                 from(components["java"])


### PR DESCRIPTION
## Description
This pull request centralizes the Maven publishing configuration in the root `build.gradle.kts` file, removing hardcoded version and group IDs from individual module `build.gradle.kts` files. The project version is now dynamically set from an environment variable or defaults to `0.0.1-SNAPSHOT`.

Additionally, the `README.md` has been updated to reflect these changes, using `<version>` placeholders for dependencies and providing a link to the GitHub releases page for specific versions. A new step has been added to the CI workflow to verify the publishing process by running `./gradlew publishToMavenLocal`.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [x] CI/CD configuration change
- [ ] Other (please describe):

## How to Test
The changes can be tested by running the CI pipeline. The added `publishToMavenLocal` step in `.github/workflows/build.yml` will verify that the publishing configuration is correct and the artifacts can be built and published locally.
Check if Link in the readme works.
Ensure JitPack succesfully [build the project](https://jitpack.io/com/github/appunite/MockWebServer-Extensions/71195bebc1/build.log)

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional Notes
This change simplifies version management and ensures consistency across all published modules.